### PR TITLE
correcting the overflow of the footer DIV that leaving a blank space after footer

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -20,7 +20,7 @@ footer .footer-links>div{
 
 footer .footer > div > div {
   padding-top: 6rem;
-  padding-bottom: 3rem;
+  padding-bottom: 1rem;
 }
 
 footer .footer-links > div > div{


### PR DESCRIPTION


Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #8 

Test URLs:
- Before: https://main--adobe-franklin-demo--amol-anand.hlx.page/
- After: https://issue-8-footer--adobe-franklin-demo--amol-anand.hlx.page/

