### PR TITLE
fix: delay video loading til user initiates it

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -68,7 +68,7 @@ export default async function decorate(block) {
           </button>
         </div>
         <div class="cmp-modal-content">
-          <video class="cmp-modal-video" autoPlay="" controls="" muted="" playsInline="" loop="" preload="auto">
+          <video class="cmp-modal-video" autoPlay="" controls="" muted="" playsInline="" loop="" preload="none">
             <source data-label="${cfg.name}" data-title="${cfg.name}"
                     src="${cfg.video}" type="video/mp4">
             <track src="" kind="subtitles" srcLang="en" label="English">


### PR DESCRIPTION
Decrease TBT by not preloading the video which is only played when user clicks. see https://web.dev/lazy-loading-video/

Test URLs:
- Before: https://main--adobe-franklin-demo--amol-anand.hlx.page/
- After: https://video-preload--adobe-franklin-demo--amol-anand.hlx.page/

TBH, not totally sure how much difference this makes, but I noticed that the .page domain is occasionally reporting some lower scores and this seems to help a bit.