### PR TITLE
Added check to ensure only H2 and Link will trigger the CTA Auto block

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -31,10 +31,12 @@ function buildCtaBlock(main) {
   main.querySelectorAll(':scope > div').forEach((div) => {
     const h2 = div.querySelector(':scope > h2');
     const p = div.querySelector(':scope > p');
+    const numChildren = div.children.length;
     if (p) {
       const a = p.querySelector('a');
       // eslint-disable-next-line no-bitwise
-      if (h2 && p && a && (h2.compareDocumentPosition(p) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+      if (h2 && p && a && (h2.compareDocumentPosition(p) & Node.DOCUMENT_POSITION_FOLLOWING)
+           && (numChildren === 2)) {
         div.classList.add('cta');
       }
     }


### PR DESCRIPTION
added logic to also check if that section div only has two elements. If it has more, then this auto block will not kick in.

Test URLs:
- Before: https://main--adobe-franklin-demo--amol-anand.hlx.page/
- After: https://minor-tweaks--adobe-franklin-demo--amol-anand.hlx.page/
